### PR TITLE
remove references to bitbucket where applicable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Replace it with your own EnMAP-Box fork from which you can create pull requests.
 2. Clone the EnMAP-Box repository.
    
     ````bash
-    git clone git@bitbucket.org:hu-geomatics/enmap-box.git
+    git clone git@github.com:EnMAP-Box/enmap-box.git
     ````
     
    You might also use the url `https://github.com/EnMAP-Box/enmap-box.git` instead. 
@@ -80,7 +80,7 @@ Replace it with your own EnMAP-Box fork from which you can create pull requests.
     Of course cloning and submodule updating can be done in one step:
     ````bash
     
-    git clone --recurse-submodules git@bitbucket.org:hu-geomatics/enmap-box.git
+    git clone --recurse-submodules git@github.com:EnMAP-Box/enmap-box.git
     ````
     
     At any later point, you can pull in submodule updates by

--- a/enmapbox/algorithmprovider.py
+++ b/enmapbox/algorithmprovider.py
@@ -135,7 +135,7 @@ class EnMAPBoxProcessingProvider(QgsProcessingProvider):
         return ID
 
     def helpid(self) -> str:
-        return 'https://bitbucket.org/hu-geomatics/enmap-box/wiki/Home'
+        return 'https://enmap-box.readthedocs.io/en/latest/'
 
     def icon(self) -> QIcon:
         """


### PR DESCRIPTION
After I completely botched my local git history, I re-forked the repo and re-opened this PR. A naiive way to find other occurences of bitbucket would be to run `find . -type f \( ! -iname '*.png' ! -iname '*.ico' ! -iname '*.svg' ! -iname '*.jpg' ! -iname '*.jpeg' \) -exec sed --in-place --expression '/[iI]ssue/! s/bitbucket\.org/github\.com/g' --separate {} \;` and look at the diffs 