### PR TITLE
33 attribute form doesnt appears on enmap box map

### DIFF
--- a/enmapbox/gui/datasources/manager.py
+++ b/enmapbox/gui/datasources/manager.py
@@ -539,7 +539,7 @@ class DataSourceManagerTreeView(TreeView):
 
             elif isinstance(node, VectorDataSource):
 
-                if node.wkbType() not in [QgsWkbTypes.NoGeometry, QgsWkbTypes.Unknown, QgsWkbTypes.UnknownGeometry]:
+                if node.geometryType() not in [QgsWkbTypes.NullGeometry, QgsWkbTypes.UnknownGeometry]:
                     a = m.addAction('Open in new map')
                     a.triggered.connect(lambda *args, s=node: self.openInMap(s, None))
 

--- a/enmapboxprocessing/test/algorithm/test_SampleRasterValuesAlgorithm.py
+++ b/enmapboxprocessing/test/algorithm/test_SampleRasterValuesAlgorithm.py
@@ -1,14 +1,14 @@
 from enmapbox.exampledata import enmap, landcover_polygons
 from enmapboxprocessing.algorithm.samplerastervaluesalgorithm import SampleRasterValuesAlgorithm
 from enmapboxprocessing.test.algorithm.testcase import TestCase
-from enmapboxtestdata import landcover_points_singlepart_epsg3035
+from enmapboxtestdata import landcover_points_singlepart_epsg3035, enmap_uncompressed
 from qgis.core import (QgsRasterLayer, QgsVectorLayer)
 
 
 class TestSampleRasterValuesAlgorithm(TestCase):
 
     def test_sampleFromVectorPoints(self):
-        global c
+
         alg = SampleRasterValuesAlgorithm()
         alg.initAlgorithm()
         parameters = {
@@ -19,7 +19,7 @@ class TestSampleRasterValuesAlgorithm(TestCase):
         result = self.runalg(alg, parameters)
 
     def test_sampleFromVectorPolygons(self):
-        global c
+
         alg = SampleRasterValuesAlgorithm()
         alg.initAlgorithm()
         parameters = {

--- a/scripts/create_plugin.py
+++ b/scripts/create_plugin.py
@@ -42,7 +42,7 @@ app = start_app()
 import enmapbox
 from enmapbox import DIR_REPO
 from enmapbox.qgispluginsupport.qps.make.deploy import QGISMetadataFileWriter, userProfileManager
-from enmapbox.gui.utils import zipdir
+from enmapbox.qgispluginsupport.qps.utils import zipdir
 from qgis.core import QgsFileUtils
 
 


### PR DESCRIPTION
provides several updates to the qps maptool reimplementation of a QgsFeatureAction 
default settings are now read from QgsSettingsRegistryCore
(QgsFeatureActions are not available in PyQGIS)