### PR TITLE
changed QgsSettings organization from HU-Berlin to EnMAP, resolves #69

### DIFF
--- a/enmapbox/settings.py
+++ b/enmapbox/settings.py
@@ -9,7 +9,7 @@ class EnMAPBoxSettings(QgsSettings):
     MAP_BACKGROUND = 'MAP_BACKGROUND'
 
     def __init__(self):
-        super().__init__('HU-Berlin', 'EnMAP-Box')
+        super().__init__('EnMAP', 'EnMAP-Box')
 
         # init default settings
         self.setIfUndefined(self.SHOW_WARNING, True)

--- a/tests/src/core/test_settings.py
+++ b/tests/src/core/test_settings.py
@@ -15,18 +15,15 @@
 *                                                                         *
 ***************************************************************************
 """
-# noinspection PyPep8Naming
-import pathlib
-import unittest
 import os
-
-from qgis.PyQt.QtGui import QColor
-
-from enmapbox.settings import enmapboxSettings, EnMAPBoxSettings
-from qgis.core import QgsProject
+# noinspection PyPep8Naming
+import unittest
 
 from enmapbox import EnMAPBox
+from enmapbox.settings import enmapboxSettings, EnMAPBoxSettings
 from enmapbox.testing import EnMAPBoxTestCase
+from qgis.PyQt.QtGui import QColor
+from qgis.core import QgsProject
 
 
 class TestEnMAPBoxPlugin(EnMAPBoxTestCase):

--- a/tests/src/otherapps/test_lmuvegetationapps.py
+++ b/tests/src/otherapps/test_lmuvegetationapps.py
@@ -22,7 +22,6 @@ initPythonPaths()
 site.addsitedir(pathlib.Path(DIR_ENMAPBOX) / 'apps' / 'lmuapps')
 
 
-
 class test_applications(EnMAPBoxTestCase):
 
     def test_MainUiFunc(self):


### PR DESCRIPTION
@thielfab this should change the config file folder to 'EnMAP'

Signed-off-by: Benjamin Jakimow benjamin.jakimow@geo.hu-berlin.de <benjamin.jakimow@geo.hu-berlin.de>