### PR TITLE
Fix crashing create_plugin.py build script.

### DIFF
--- a/scripts/create_plugin.py
+++ b/scripts/create_plugin.py
@@ -185,7 +185,7 @@ def create_enmapbox_plugin(include_testdata: bool = False,
 
     PATH_METADATAFILE = PLUGIN_DIR / 'metadata.txt'
 
-    pathAbout = DIR_REPO / 'About.md'
+    pathAbout = DIR_REPO / 'ABOUT.md'
 
     # set QGIS Metadata file values
     MD = QGISMetadataFileWriter()


### PR DESCRIPTION
This fixes the following exception when calling the build script:

```python
(qgis_stable) gfz-fe@geoms:~/scheffler/python/enmap-box$ python scripts/create_plugin.py 
Application state:
QGIS_PREFIX_PATH env var:               /home/gfz-fe/mambaforge/envs/qgis_stable
Prefix:         /home/gfz-fe/mambaforge/envs/qgis_stable
Plugin Path:            /home/gfz-fe/mambaforge/envs/qgis_stable/lib/qgis/plugins
Package Data Path:      /home/gfz-fe/mambaforge/envs/qgis_stable/share/qgis
Active Theme Name:      
Active Theme Path:      /home/gfz-fe/mambaforge/envs/qgis_stable/share/qgis/resources/themes//icons/
Default Theme Path:     :/images/themes/default/
SVG Search Paths:       /home/gfz-fe/mambaforge/envs/qgis_stable/share/qgis/svg/
                /tmp/QGIS-PythonTestConfigPath-qiibui1a/profiles/default/svg/
User DB Path:   /home/gfz-fe/mambaforge/envs/qgis_stable/share/qgis/resources/qgis.db
Auth DB Path:   /tmp/QGIS-PythonTestConfigPath-qiibui1a/profiles/default/qgis-auth.db

Traceback (most recent call last):
  File "/home/gfz-fe/scheffler/python/enmap-box/scripts/create_plugin.py", line 459, in <module>
    path = create_enmapbox_plugin(include_testdata=args.testdata,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gfz-fe/scheffler/python/enmap-box/scripts/create_plugin.py", line 199, in create_enmapbox_plugin
    MD.mAbout = markdownToHTML(pathAbout)
                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gfz-fe/scheffler/python/enmap-box/scripts/create_plugin.py", line 349, in markdownToHTML
    with open(path_md, 'r', encoding='utf-8') as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/gfz-fe/scheffler/python/enmap-box/About.md'
Segmentation fault
```