### PR TITLE
588 rename exampledata vars

### DIFF
--- a/enmapbox/coreapps/metadataeditorapp/metadatakeys.py
+++ b/enmapbox/coreapps/metadataeditorapp/metadatakeys.py
@@ -418,7 +418,7 @@ class MDKeyDomainString(MDKeyAbstract):
     def setValue(self, value):
 
         def convertOrFail(value):
-            if type(value) != self.mType:
+            if type(value) is not self.mType:
                 try:
                     value = self.mType(value)
                 except Exception as ex:

--- a/enmapbox/dependencycheck.py
+++ b/enmapbox/dependencycheck.py
@@ -498,7 +498,7 @@ def missingTestData() -> bool:
     """
     try:
         import enmapbox.exampledata
-        assert os.path.isfile(enmapbox.exampledata.enmap_potsdam)
+        assert os.path.isfile(enmapbox.exampledata.enmap)
         return False
     except Exception as ex:
         print(ex, file=sys.stderr)

--- a/enmapbox/exampledata/__init__.py
+++ b/enmapbox/exampledata/__init__.py
@@ -1,6 +1,6 @@
 from os.path import dirname, join
 
-aerial_potsdam = join(dirname(__file__), 'aerial_potsdam.tif')
-enmap_potsdam = join(dirname(__file__), 'enmap_potsdam.tif')
-landcover_potsdam_point = join(dirname(__file__), 'landcover_potsdam_point.gpkg')
-landcover_potsdam_polygon = join(dirname(__file__), 'landcover_potsdam_polygon.gpkg')
+hires = join(dirname(__file__), 'aerial_potsdam.tif')
+enmap = join(dirname(__file__), 'enmap_potsdam.tif')
+landcover_point = join(dirname(__file__), 'landcover_potsdam_point.gpkg')
+landcover_polygon = join(dirname(__file__), 'landcover_potsdam_polygon.gpkg')

--- a/enmapbox/gui/enmapboxgui.py
+++ b/enmapbox/gui/enmapboxgui.py
@@ -1880,9 +1880,9 @@ class EnMAPBox(QgisInterface, QObject, QgsExpressionContextGenerator, QgsProcess
                 lyrs = [lyr for lyr in sorted(lyrs, key=niceLayerOrder)]
 
                 # quick fix for issue #555
-                from enmapbox.exampledata import enmap_potsdam, aerial_potsdam
+                from enmapbox.exampledata import enmap, hires
                 lyrNames = [basename(lyr.source()) for lyr in lyrs]
-                a, b = lyrNames.index(basename(aerial_potsdam)), lyrNames.index(basename(enmap_potsdam))
+                a, b = lyrNames.index(basename(hires)), lyrNames.index(basename(enmap))
                 lyrs[b], lyrs[a] = lyrs[a], lyrs[b]  # we just switch positions
 
                 for lyr in lyrs:

--- a/tests/src/core/test_datasources.py
+++ b/tests/src/core/test_datasources.py
@@ -23,12 +23,12 @@ from qgis.PyQt import sip
 from qgis.core import QgsProject, QgsMapLayer, QgsRasterLayer, QgsVectorLayer, QgsRasterRenderer, QgsRasterDataProvider
 from qgis.gui import QgsMapCanvas
 
-from enmapbox.exampledata import enmap, hires, landcover_polygon, library_gpkg, enmap_srf_library
+from enmapbox.exampledata import enmap, hires, landcover_polygon
 from enmapbox.gui.datasources.datasources import SpatialDataSource, DataSource, RasterDataSource, VectorDataSource, \
     FileDataSource
 from enmapbox.gui.datasources.manager import DataSourceManager, DataSourceManagerPanelUI, DataSourceFactory
 from enmapbox.testing import TestObjects, EnMAPBoxTestCase
-from enmapboxtestdata import classifierDumpPkl
+from enmapboxtestdata import classifierDumpPkl, library_berlin, enmap_srf_library
 
 
 class DataSourceTests(EnMAPBoxTestCase):
@@ -82,7 +82,7 @@ class DataSourceTests(EnMAPBoxTestCase):
     def createTestSources(self) -> list:
 
         # return [library, self.wfsUri, self.wmsUri, enmap, landcover_polygons]
-        return [library_gpkg, enmap, landcover_polygon]
+        return [library_berlin, enmap, landcover_polygon]
 
     def createOGCSources(self) -> list:
         # todo: add WCS
@@ -146,7 +146,7 @@ class DataSourceTests(EnMAPBoxTestCase):
         dsm = DataSourceManager()
         panel = DataSourceManagerPanelUI()
         panel.connectDataSourceManager(dsm)
-        uris = [library_gpkg, enmap, landcover_polygon]
+        uris = [library_berlin, enmap, landcover_polygon]
         dsm.addDataSources(uris)
         self.showGui(panel)
 
@@ -192,14 +192,14 @@ class DataSourceTests(EnMAPBoxTestCase):
         self.assertTrue(ds2.updateTime() > t0_2)
 
     def test_DataSourceModel(self):
-        from enmapbox.exampledata import enmap, landcover_polygon, library_gpkg, enmap_srf_library
+
         sources = [enmap,
                    enmap,
                    landcover_polygon,
                    landcover_polygon,
                    enmap_srf_library,
                    enmap_srf_library,
-                   library_gpkg,
+                   library_berlin,
                    classifierDumpPkl]
 
         model = DataSourceManager()

--- a/tests/src/core/test_docksanddatasources.py
+++ b/tests/src/core/test_docksanddatasources.py
@@ -16,7 +16,7 @@ import os
 import tempfile
 import unittest
 
-from enmapbox.exampledata import landcover_polygon, library_gpkg, enmap, hires
+from enmapbox.exampledata import landcover_polygon, enmap, hires
 from enmapbox.gui.datasources.datasources import VectorDataSource, RasterDataSource
 from enmapbox.gui.datasources.manager import DataSourceManager
 from enmapbox.gui.dataviews.dockmanager import DockManager, SpeclibDockTreeNode, MapDockTreeNode, \
@@ -26,7 +26,7 @@ from enmapbox.gui.enmapboxgui import EnMAPBox
 from enmapbox.qgispluginsupport.qps.pyqtgraph.pyqtgraph.dockarea.Dock import Dock as pgDock
 from enmapbox.qgispluginsupport.qps.speclib.core import is_spectral_library
 from enmapbox.testing import EnMAPBoxTestCase, TestObjects
-from enmapboxtestdata import classificationDatasetAsPklFile
+from enmapboxtestdata import classificationDatasetAsPklFile, library_berlin
 from qgis.PyQt.QtWidgets import QApplication
 from qgis.core import QgsProject, QgsVectorLayer, QgsRasterLayer, QgsLayerTreeModel, QgsLayerTree
 from qgis.gui import QgsMapCanvas, QgsLayerTreeView
@@ -50,7 +50,7 @@ class TestDocksAndDataSources(EnMAPBoxTestCase):
 
         DSM.addDataSources(enmap)
         DSM.addDataSources(landcover_polygon)
-        DSM.addDataSources(library_gpkg)
+        DSM.addDataSources(library_berlin)
 
         self.assertTrue(len(signalArgs) == 3)
         self.assertIsInstance(signalArgs[0], RasterDataSource)

--- a/tests/src/core/test_mapcanvas.py
+++ b/tests/src/core/test_mapcanvas.py
@@ -15,13 +15,14 @@ import pathlib
 import unittest
 
 from enmapbox.gui.enmapboxgui import EnMAPBox
-from enmapbox.exampledata import enmap, hires, landcover_polygon, library_gpkg
+from enmapbox.exampledata import enmap, hires, landcover_polygon
 from enmapbox.gui.dataviews.dockmanager import MapDockTreeNode
 from enmapbox.gui.dataviews.docks import MapDock
 from enmapbox.gui.mapcanvas import CanvasLink, MapCanvas, KEY_LAST_CLICKED, LINK_ON_CENTER
 from enmapbox.qgispluginsupport.qps.maptools import CursorLocationMapTool, MapTools
 from enmapbox.testing import EnMAPBoxTestCase
 from enmapbox.testing import TestObjects
+from enmapboxtestdata import library_berlin
 from qgis.PyQt.QtCore import QMimeData, QUrl
 from qgis.PyQt.QtGui import QKeyEvent
 from qgis.PyQt.QtWidgets import QMenu, QAction
@@ -162,7 +163,7 @@ class MapCanvasTests(EnMAPBoxTestCase):
         mapDock = MapDock()
         node = MapDockTreeNode(mapDock)
         mapCanvas = mapDock.mapCanvas()
-        allFiles = [enmap, hires, landcover_polygon, library_gpkg]
+        allFiles = [enmap, hires, landcover_polygon, library_berlin]
         spatialFiles = [enmap, hires, landcover_polygon]
 
         md = QMimeData()

--- a/tests/src/core/test_mimedata.py
+++ b/tests/src/core/test_mimedata.py
@@ -19,8 +19,9 @@ import unittest
 import enmapbox.gui.mimedata as mimedata
 from enmapbox import DIR_EXAMPLEDATA
 from enmapbox.gui.enmapboxgui import EnMAPBox
-from enmapbox.exampledata import enmap, hires, library_gpkg, landcover_polygon
+from enmapbox.exampledata import enmap, hires, landcover_polygon
 from enmapbox.testing import EnMAPBoxTestCase
+from enmapboxtestdata import library_berlin
 from qgis.PyQt.QtCore import QMimeData, QByteArray, QUrl, Qt, QPoint
 from qgis.PyQt.QtGui import QDropEvent
 from qgis.PyQt.QtWidgets import QApplication
@@ -65,7 +66,7 @@ class MimeDataTests(EnMAPBoxTestCase):
         from enmapbox.gui.datasources.datasources import DataSource
         from enmapbox.gui.datasources.manager import DataSourceFactory
 
-        dataSources = DataSourceFactory.create([enmap, hires, library_gpkg, landcover_polygon])
+        dataSources = DataSourceFactory.create([enmap, hires, library_berlin, landcover_polygon])
         dataSourceObjectIDs = [id(ds) for ds in dataSources]
 
         md = mimedata.fromDataSourceList(dataSources)

--- a/tests/src/core/test_speclibs.py
+++ b/tests/src/core/test_speclibs.py
@@ -17,7 +17,7 @@ import unittest
 from qgis.core import QgsFeature
 
 from enmapbox.gui.enmapboxgui import EnMAPBox
-from enmapbox.exampledata import enmap, enmap_srf_library
+from enmapbox.exampledata import enmap
 from enmapbox.gui.dataviews.docks import SpectralLibraryDock
 from enmapbox.gui.mapcanvas import MapCanvas
 from enmapbox.qgispluginsupport.qps.speclib.core.spectralprofile import encodeProfileValueDict
@@ -25,7 +25,7 @@ from enmapbox.qgispluginsupport.qps.utils import fid2pixelindices, SpatialPoint
 from enmapbox.testing import EnMAPBoxTestCase
 from qgis.gui import QgsMapLayerComboBox
 from qgis.core import QgsRasterLayer, QgsVectorLayer
-from enmapboxtestdata import fraction_polygon_l3, fraction_point_singletarget
+from enmapboxtestdata import fraction_polygon_l3, fraction_point_singletarget, enmap_srf_library
 
 
 class TestSpeclibs(EnMAPBoxTestCase):

--- a/tests/src/core/test_spectral_processing.py
+++ b/tests/src/core/test_spectral_processing.py
@@ -9,7 +9,6 @@ from enmapbox.qgispluginsupport.qps.speclib.gui.spectrallibrarywidget import Spe
 from enmapbox.testing import EnMAPBoxTestCase
 
 
-
 class TestSpectralProcessing(EnMAPBoxTestCase):
 
     def setUp(self):
@@ -20,7 +19,6 @@ class TestSpectralProcessing(EnMAPBoxTestCase):
 
     @unittest.skipIf(EnMAPBoxTestCase.runsInCI(), 'blocking dialog')
     def test_spectralProcessingDialog(self):
-
         EMB = EnMAPBox(load_core_apps=True, load_other_apps=False)
         # EMB.loadExampleData()
         speclib = QgsVectorLayer(library_berlin, 'Speclib')

--- a/tests/src/core/test_spectral_processing.py
+++ b/tests/src/core/test_spectral_processing.py
@@ -1,12 +1,13 @@
 import unittest
 
+from enmapboxtestdata import library_berlin
 from qgis.core import QgsVectorLayer
 
 from enmapbox.gui.enmapboxgui import EnMAPBox
 from enmapbox.gui.dataviews.docks import DockTypes, SpectralLibraryDock
 from enmapbox.qgispluginsupport.qps.speclib.gui.spectrallibrarywidget import SpectralLibraryWidget
 from enmapbox.testing import EnMAPBoxTestCase
-from enmapbox.exampledata import library_gpkg
+
 
 
 class TestSpectralProcessing(EnMAPBoxTestCase):
@@ -22,7 +23,7 @@ class TestSpectralProcessing(EnMAPBoxTestCase):
 
         EMB = EnMAPBox(load_core_apps=True, load_other_apps=False)
         # EMB.loadExampleData()
-        speclib = QgsVectorLayer(library_gpkg, 'Speclib')
+        speclib = QgsVectorLayer(library_berlin, 'Speclib')
         speclib.startEditing()
         SLD: SpectralLibraryDock = EMB.createDock(DockTypes.SpectralLibraryDock, speclib=speclib)
         SLW: SpectralLibraryWidget = SLD.speclibWidget()

--- a/tests/src/enmapboxtestdata.py
+++ b/tests/src/enmapboxtestdata.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import platform
 import warnings
 from os.path import join, dirname, abspath
@@ -10,9 +11,9 @@ _root = abspath(join(dirname(dirname(__file__)), 'testdata'))
 
 # Berlin example data
 # ...this is the old example dataset, which we still need for unittests
-_subdir = 'exampledata/berlin'
+_subdir = pathlib.Path('exampledata/berlin')
 enmap_berlin = join(_root, _subdir, 'enmap_berlin.bsq')
-enmap_srf_library = join(dirname(__file__), 'enmap_srf_library.gpkg')
+enmap_srf_library = join(_root, _subdir, 'enmap_srf_library.gpkg')
 hires_berlin = join(_root, _subdir, 'hires_berlin.bsq')
 landcover_berlin_point = join(_root, _subdir, 'landcover_berlin_point.gpkg')
 landcover_berlin_polygon = join(_root, _subdir, 'landcover_berlin_polygon.gpkg')
@@ -21,9 +22,9 @@ veg_cover_fraction_berlin_point = join(_root, _subdir, 'veg-cover-fraction_berli
 
 # Potsdam example data
 # ...current example dataset is placed under enmapbox.exampledata
-enmap_potsdam = enmapbox.exampledata.enmap_potsdam
-landcover_potsdam_polygon = enmapbox.exampledata.landcover_potsdam_polygon
-landcover_potsdam_point = enmapbox.exampledata.landcover_potsdam_point
+enmap_potsdam = enmapbox.exampledata.enmap
+landcover_potsdam_polygon = enmapbox.exampledata.landcover_polygon
+landcover_potsdam_point = enmapbox.exampledata.landcover_point
 
 # connect old shortcuts (requested by @jakimow)
 enmap = enmap_berlin

--- a/tests/src/otherapps/test_ensomap.py
+++ b/tests/src/otherapps/test_ensomap.py
@@ -29,7 +29,7 @@ def has_package(name: str):
     try:
         __import__(name)
         return True
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, SystemError):
         return False
 
 


### PR DESCRIPTION
Addresses #588 and #594
- renamed exampledata variable `aerial` back to `hires`. Future high-resolution datasets may be from highres spaceborn sensors. This way we do not need to change the variable name again
- fixed `enmap_srf_library` path in enmapboxtestdata.py
- consistent path separators no when using subpath `exampledata/berlin` (`<path>\exampledata\berlin\<path>` instead `<path>\exampledata/berlin\<path>`)

