### PR TITLE
Ensomap AttributeError fix

### DIFF
--- a/enmapbox/apps/ensomap/hys/data.py
+++ b/enmapbox/apps/ensomap/hys/data.py
@@ -415,11 +415,11 @@ class data:
         
         # get bbl
         bbl = self.meta.get("bbl")
-        if bbl is not None: bbl = np.asarray(bbl, dtype=np.int)
-        else: bbl = np.ones(self.bands, dtype=np.int)
+        if bbl is not None: bbl = np.asarray(bbl, dtype=np.int_)
+        else: bbl = np.ones(self.bands, dtype=np.int_)
         
         # get band indices
-        bind = np.arange(self.bands, dtype=np.int)
+        bind = np.arange(self.bands, dtype=np.int_)
         
         # remove bad band
         ind = np.where(bbl == 1)

--- a/enmapbox/apps/ensomap/hys/data.py
+++ b/enmapbox/apps/ensomap/hys/data.py
@@ -415,11 +415,11 @@ class data:
         
         # get bbl
         bbl = self.meta.get("bbl")
-        if bbl is not None: bbl = np.asarray(bbl, dtype=np.int_)
-        else: bbl = np.ones(self.bands, dtype=np.int_)
+        if bbl is not None: bbl = np.asarray(bbl, dtype=np.int16)
+        else: bbl = np.ones(self.bands, dtype=np.int16)
         
         # get band indices
-        bind = np.arange(self.bands, dtype=np.int_)
+        bind = np.arange(self.bands, dtype=np.int16)
         
         # remove bad band
         ind = np.where(bbl == 1)


### PR DESCRIPTION
I fixed a the AttributeError raised in the data.py file when calling a module NumPy > 1.20, caused by deprecated alias np.int (as referred in https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)