### PR TITLE
Add a z-profile from values averaged over a polygon mask.

### DIFF
--- a/enmapbox/eo4qapps/profileanalyticsapp/profileanalyticsdockwidget.ui
+++ b/enmapbox/eo4qapps/profileanalyticsapp/profileanalyticsdockwidget.ui
@@ -166,6 +166,11 @@
                    <string>Profile along selected vector-line (single band)</string>
                   </property>
                  </item>
+                 <item>
+                  <property name="text">
+                   <string>Z-Profile over a polygon (all bands)</string>
+                  </property>
+                 </item>
                 </widget>
                </item>
                <item row="1" column="1">
@@ -301,7 +306,7 @@
                          </sizepolicy>
                         </property>
                         <property name="text">
-                         <string>map tool to select a vector-line.</string>
+                         <string>map tool to select a vector shape.</string>
                         </property>
                        </widget>
                       </item>


### PR DESCRIPTION
Hi,

We discovered and started using your project at Laboratoire de Géologie de Lyon to analyze martian orbital hyperspectral imagery, thank you for making this public!

We have added a feature to the toolbox to allow to create z-profiles that are computed not on one point, but using the average values within a mask defined by a polygon. This helps in some noisy cases, or to create overall profiles of identified areas/geological units.

Would you consider including it in the project? We tried to re-use (and generalize) the vector layer association from line profiles, but keeping overall the behavior of z-profile.

I don't think I was existing testcases for these functions to complete?

Regards,

Authorship:
- Ines Torres, Phd student, LGLTPE / Université Claude Bernard Lyon 1
- Matthieu Volat, CNRS engineer, Observatoire de Lyon 