### PR TITLE
Update qps

### DIFF
--- a/.github/workflows/urlcheck.yml
+++ b/.github/workflows/urlcheck.yml
@@ -39,7 +39,7 @@ jobs:
         # {z]/{y}/{x}: CartoDB, Open Weather, OpenTopoMap, OSM, Stamen, Strava, Wikimedia
         # x={x}&y={y}&z={z}: Google
         exclude_urls:
-          https://.*,https://bitbucket.org/hu-geomatics/enmap-box/issues//422,http://mrcc.com/qgis.dtd
+          https://.*,https://bitbucket.org/hu-geomatics/enmap-box/issues//422,http://mrcc.com/qgis.dtd,http://www.wtfpl.net/
 
         exclude_patterns:
           http://ecn.t3.tiles.virtualearth.net/,%7Bz%7D/%7By%7D/%7Bx%7D,%7Bz%7D/%7Bx%7D/%7By%7D,x%3D%7Bx%7D%26y%3D%7By%7D%26z%3D%7Bz%7D,https://fbinter.stadt-berlin.de/,https://tiles.wmflabs.org/


### PR DESCRIPTION
fixes https://github.com/EnMAP-Box/qgispluginsupport/issues/41
excludes failing link to http://www.wtfpl.net/  from url check