### PR TITLE
[EnSoMAP] Rename "organic matter content" to "organic carbon content".

### DIFF
--- a/enmapbox/apps/ensomap/README.md
+++ b/enmapbox/apps/ensomap/README.md
@@ -36,9 +36,9 @@ Table 2.1:	Overview of HYSOMA automatic soil functions for identification and se
 | **Carbonates**<br>Mg-OH content | Carbonate absorp-tion depth SWIR | 2300 – 2400 | Carbonate content |
 |**Soil Moisture** | Moisture index (NSMI) | 1800, 2119 | Soil moisture content (Haubrock et al. 2008a/b)|
 | | Gaussian modelling (SMGM | ~1500 – 2500 | Soil moisture content (Whiting et al. 2004) |
-| **Soil Organic Carbon** | Band analysis SOC 1 | 400 – 700 | Organic matter content (Bartholomeus et al. 2008) |
-| | Band analysis SOC 2 | 400, 600 | Organic matter content (Bartholomeus et al. 2008) |
-| | Band analysis SOC 3 | 2138 – 2209 | Organic matter content (Bartholomeus et al. 2008) |
+| **Soil Organic Carbon** | Band analysis SOC 1 | 400 – 700 | Organic carbon content (Bartholomeus et al. 2008) |
+| | Band analysis SOC 2 | 400, 600 | Organic carbon content (Bartholomeus et al. 2008) |
+| | Band analysis SOC 3 | 2138 – 2209 | Organic carbon content (Bartholomeus et al. 2008) |
 |**Gypsum** | NDGI | | |
 
 # Soil Analyses Tools

--- a/enmapbox/apps/ensomap/hys/feat_specan_oc1.py
+++ b/enmapbox/apps/ensomap/hys/feat_specan_oc1.py
@@ -14,7 +14,7 @@ from hys.tools import get_continuum_line
 __bands__    = [400, 700]
 __filename__ = "_OC_SUM_400_700"
 __gui__      = "SOC Index: 1/sum(R400 - R700)"
-__info__     = "Organic matter content: \n"+\
+__info__     = "Organic carbon content: \n"+\
     "Calculate the inverse of the sum of the total reflectance \n"+\
     "minus the continuum removed function:\n\n"+\
     "ind = 1/sum(R_400 to R_700)\n\n"+\

--- a/enmapbox/apps/ensomap/hys/feat_specan_oc2.py
+++ b/enmapbox/apps/ensomap/hys/feat_specan_oc2.py
@@ -13,7 +13,7 @@ import numba as nb
 __bands__    = [400, 600]
 __filename__ = "_OC_SLOPE_400_600"
 __gui__      = "SOC Index: 1/slope(R400 - R600)"
-__info__     = "Organic matter content: \n"+\
+__info__     = "Organic carbon content: \n"+\
     "Calculate the inverse of the slope of a straight line defined\n"+\
     "between the reflectance value at the start of the absorption feature \n"+\
     "and the reflectance value at the centre of the absorption feature:\n\n"+\

--- a/enmapbox/apps/ensomap/hys/feat_specan_oc3.py
+++ b/enmapbox/apps/ensomap/hys/feat_specan_oc3.py
@@ -13,7 +13,7 @@ import numba as nb
 __bands__    = [2138, 2209]
 __filename__ = "_OC_SLOPE_2138_2209"
 __gui__      = "SOC Index: 1/slope(R2138 - R2209)"
-__info__     = "Indirect organic matter content: \n"+\
+__info__     = "Indirect organic carbon content: \n"+\
     "Calculate the inverse of the slope of a straight line defined\n"+\
     "between the reflectance value at the start of the absorption feature \n"+\
     "and the reflectance value at the centre of the absorption feature:\n\n"+\

--- a/enmapbox/apps/ensomap/hys/feat_specan_oc4.py
+++ b/enmapbox/apps/ensomap/hys/feat_specan_oc4.py
@@ -11,7 +11,7 @@ import numba as nb
 __bands__    = [478, 546, 659]
 __filename__ = "_OC_VISonly_478_546_659"
 __gui__      = "SOC Index: R478 / (R659 * R546)"
-__info__     = "Organic matter content: \n"+\
+__info__     = "Organic carbon content: \n"+\
     "Calculate a SOC index based solely on visible wavelengths: \n\n"+\
     "ind = R_478 / (R_659 * R_546)\n\n"+\
     "Thaler, E.A., Larsen, I.J., Yu, Q., 2019. \n"+\


### PR DESCRIPTION
This is a simple text replacement - also a request from Kathrin.

<img width="396" height="224" alt="image" src="https://github.com/user-attachments/assets/19486491-d319-4b81-a649-90eb9082928c" />
