### PR TITLE
Implements #1324: add run_eniccs from the eniccs package as a processing algorithm

### DIFF
--- a/.env/requirements.csv
+++ b/.env/requirements.csv
@@ -10,7 +10,7 @@ numba,,0.57
 netCDF4,,,required by ONNS
 GDAL,osgeo.gdal,,Installed with QGIS
 numpy,,,Installed with QGIS
-eniccs,,0.2.3,Required by EnICCS application
+eniccs,,0.2.4,Required by EnICCS application
 # torch,,,Required by SpecDeepMap application
 # lightning,,,Required by SpecDeepMap application
 # tensorboard,,,Required by SpecDeepMap application

--- a/.env/requirements.csv
+++ b/.env/requirements.csv
@@ -10,6 +10,7 @@ numba,,0.57
 netCDF4,,,required by ONNS
 GDAL,osgeo.gdal,,Installed with QGIS
 numpy,,,Installed with QGIS
+eniccs,,0.2.3,Required by EnICCS application
 # torch,,,Required by SpecDeepMap application
 # lightning,,,Required by SpecDeepMap application
 # tensorboard,,,Required by SpecDeepMap application

--- a/enmapbox/apps/eniccsapp/__init__.py
+++ b/enmapbox/apps/eniccsapp/__init__.py
@@ -25,7 +25,7 @@ class EniccsApp(EnMAPBoxApplication):
 
     @classmethod
     def title(cls):
-        return 'EnICCS - EnMAP L2A cloud and cloud shadow mask'
+        return ('EnICCS - EnMAPs Improved Cloud and Cloud Shadows (L2A)')
 
     def menu(self, appMenu: QMenu):
         pass

--- a/enmapbox/apps/eniccsapp/eniccscloudmaskalgorithm.py
+++ b/enmapbox/apps/eniccsapp/eniccscloudmaskalgorithm.py
@@ -1,38 +1,79 @@
-from typing import Dict, Any, List, Tuple
+import contextlib
+import os
+from typing import Any, Dict, List, Tuple
 
 from qgis._core import QgsProcessingParameterFile
-from qgis.core import QgsProcessingContext, QgsProcessingFeedback
+from qgis.core import (
+    QgsProcessingContext,
+    QgsProcessingException,
+    QgsProcessingFeedback,
+    QgsProcessingOutputRasterLayer
+)
+try:
+    from eniccs import run_eniccs
+except ImportError:
+    run_eniccs = None
 
 from enmapbox.typeguard import typechecked
 from enmapboxprocessing.enmapalgorithm import EnMAPProcessingAlgorithm
 
+# for routing eniccs prints back to gui if verbose=True
+class _FeedbackStream:
+    def __init__(self, feedback: QgsProcessingFeedback):
+        self._feedback = feedback
+
+    def write(self, msg: str):
+        msg = msg.rstrip()
+        if msg:
+            self._feedback.pushInfo(msg)
+
+    def flush(self):
+        pass
+
 
 @typechecked
 class EniccsCloudMaskAlgorithm(EnMAPProcessingAlgorithm):
-    P_PRODUCT, _PRODUCT = 'product', 'EnMAP L2A product folder'
+    P_PRODUCT, _PRODUCT = 'product', 'EnMAP L2A product folder (single tile)'
+    P_OUTPUT_DIR, _OUTPUT_DIR = 'outputDir', 'Output folder'
     P_AUTO_OPTIMIZE, _AUTO_OPTIMIZE = 'autoOptimize', 'Auto optimize'
     P_SMOOTH, _SMOOTH = 'smoothOutput', 'Smooth output'
+    P_VERBOSE, _VERBOSE = 'verbose', 'Verbose (print progress to log)'
     P_CONTAMINATION, _CONTAMINATION = 'contamination', 'Contamination'
     P_PERCENTILE, _PERCENTILE = 'percentile', 'Percentile'
     P_SAMPLES, _SAMPLES = 'samples', 'Samples'
     P_BUFFER, _BUFFER = 'buffer', 'Buffer'
+    P_N_JOBS, _N_JOBS = 'nJobs', 'Number of parallel jobs'
+    P_OUTPUT_CLOUD, _OUTPUT_CLOUD = 'outputCloud', 'EnICCS cloud mask'
+    P_OUTPUT_SHADOW, _OUTPUT_SHADOW = 'outputCloudShadow', 'EnICCS cloud shadow mask'
 
     def displayName(self) -> str:
-        return 'EnICCS - EnMAP L2A cloud and cloud shadow mask'
+        return 'EnICCS - EnMAPs Improved Cloud and Cloud Shadows (L2A)'
 
     def shortDescription(self) -> str:
         return ('EnICCS - a tool for generating improved EnMAP L2A cloud and cloud shadow masks. '
-                'See https://github.com/leleist/eniccs for more details.')
+                'Currently optimized for densely vegetated surfaces (tropics). '
+                'See https://github.com/leleist/eniccs for more details. ')
 
     def helpParameters(self) -> List[Tuple[str, str]]:
         return [
-            (self._PRODUCT, 'Path to EnMAP L2A data.'),
-            (self._AUTO_OPTIMIZE, 'Optimize the number of latent variables for PLS-DA automatically.'),
-            (self._SMOOTH, 'Apply conservative morphological processing for smooting the output masks.'),
-            (self._CONTAMINATION, 'Contamination parameter for LOF outlier detection.'),
-            (self._PERCENTILE, 'Percentile for cloud-to-shadow matching routine distance threshol.'),
-            (self._SAMPLES, 'Number of samples for PLS-DA training.'),
-            (self._BUFFER, 'Buffer size for dilation of CCS mask outputs.')
+            (self._PRODUCT, 'Path to EnMAP L2A data directory. (one single tile)'),
+            (self._OUTPUT_DIR, 'Optional output folder for the generated masks. If left empty, '
+                               'masks are written into the input product folder.'),
+            (self._AUTO_OPTIMIZE, 'Optimize the number of latent variables for PLS-DA '
+                                  'automatically. Possibly better fit, much slower.'),
+            (self._SMOOTH, 'Apply conservative morphological processing for smoothing the output masks.'),
+            (self._VERBOSE, 'Print EnICCS progress messages into the processing log panel. '
+                            'Includes model accuracy.'),
+            (self._CONTAMINATION, 'Contamination parameter for "local outlier factor (LOF)" '
+                                  'outlier detection. Is used to ensure clean training data. '
+                                  'Not related to the perceived cloud contamination of the image. '),
+            (self._PERCENTILE, 'Percentile for cloud-to-shadow matching routine distance '
+                               'threshold. High percentile for heterogeneous cloud height.'),
+            (self._SAMPLES, 'Number of samples for PLS-DA training. Sample counts as low as 200 '
+                            'can suffice. Heterogeneous surface -> more samples.'),
+            (self._BUFFER, 'Buffer size for smoothing (dilation) of CCS mask outputs.'),
+            (self._N_JOBS, 'Number of parallel jobs (-1 = all cores). Only used when Auto '
+                           'optimize is enabled.'),
         ]
 
     def group(self):
@@ -42,25 +83,84 @@ class EniccsCloudMaskAlgorithm(EnMAPProcessingAlgorithm):
         return 'PreProcessing'
 
     def initAlgorithm(self, configuration: Dict[str, Any] = None):
-        self.addParameterFile(self.P_PRODUCT, self._PRODUCT, QgsProcessingParameterFile.Behavior.Folder)
-        self.addParameterBoolean(self.P_AUTO_OPTIMIZE, self._AUTO_OPTIMIZE, False, True)
-        self.addParameterBoolean(self.P_SMOOTH, self._SMOOTH, True, True)
-        self.addParameterFloat(self.P_CONTAMINATION, self._CONTAMINATION, 0.25)
-        self.addParameterInt(self.P_PERCENTILE, self._PERCENTILE, 85, True)
-        self.addParameterInt(self.P_SAMPLES, self._SAMPLES, 3000, True)
-        self.addParameterInt(self.P_BUFFER, self._BUFFER, 1, True)
+        self.addParameterFile(
+            self.P_PRODUCT, self._PRODUCT, behavior=QgsProcessingParameterFile.Behavior.Folder)
+        self.addParameterFile(
+            self.P_OUTPUT_DIR, self._OUTPUT_DIR,
+            behavior=QgsProcessingParameterFile.Behavior.Folder,
+            optional=True)
+        self.addParameterBoolean(self.P_AUTO_OPTIMIZE, self._AUTO_OPTIMIZE, defaultValue=False, advanced=True)
+        self.addParameterBoolean(self.P_SMOOTH, self._SMOOTH, defaultValue=True, advanced=True)
+        self.addParameterBoolean(self.P_VERBOSE, self._VERBOSE, defaultValue=False, advanced=True)
+        self.addParameterFloat(self.P_CONTAMINATION, self._CONTAMINATION, defaultValue=0.25, advanced=True)
+        self.addParameterInt(self.P_PERCENTILE, self._PERCENTILE, defaultValue=85, advanced=True)
+        self.addParameterInt(self.P_SAMPLES, self._SAMPLES, defaultValue=3000, advanced=True)
+        self.addParameterInt(self.P_BUFFER, self._BUFFER, defaultValue=1, advanced=True)
+        self.addParameterInt(self.P_N_JOBS, self._N_JOBS, defaultValue=-1, advanced=True)
+
+        self.addOutput(QgsProcessingOutputRasterLayer(self.P_OUTPUT_CLOUD, self._OUTPUT_CLOUD))
+        self.addOutput(QgsProcessingOutputRasterLayer(self.P_OUTPUT_SHADOW, self._OUTPUT_SHADOW))
 
     def processAlgorithm(
             self, parameters: Dict[str, Any], context: QgsProcessingContext, feedback: QgsProcessingFeedback
     ) -> Dict[str, Any]:
-        folder = self.parameterAsFile(parameters, self.P_PRODUCT, context)
-        autoOptimize = self.parameterAsBoolean(parameters, self.P_AUTO_OPTIMIZE, context)
+        if run_eniccs is None:
+            raise QgsProcessingException(
+                'The eniccs package is not installed. '
+                'Install it with: pip install eniccs'
+            )
+
+        folder = self.parameterAsFile(parameters, self.P_PRODUCT, context) # fallback for out_dir
+        output_dir = self.parameterAsFile(parameters, self.P_OUTPUT_DIR, context) or folder
+        auto_optimize = self.parameterAsBoolean(parameters, self.P_AUTO_OPTIMIZE, context)
+        smooth = self.parameterAsBoolean(parameters, self.P_SMOOTH, context)
+        verbose = self.parameterAsBoolean(parameters, self.P_VERBOSE, context)
         contamination = self.parameterAsFloat(parameters, self.P_CONTAMINATION, context)
         percentile = self.parameterAsInt(parameters, self.P_PERCENTILE, context)
         samples = self.parameterAsInt(parameters, self.P_SAMPLES, context)
         buffer = self.parameterAsInt(parameters, self.P_BUFFER, context)
+        n_jobs = self.parameterAsInt(parameters, self.P_N_JOBS, context)
 
-        # TODO use run_eniccs(...)
+        stdout_redirect = (
+            contextlib.redirect_stdout(_FeedbackStream(feedback)) if verbose
+            else contextlib.nullcontext()
+        )
 
-        result = {}
-        return result
+        try:
+            with stdout_redirect:
+                mask_obj = run_eniccs(
+                    dir_path=folder,
+                    output_dir=output_dir,
+                    save_output=True,
+                    return_mask_obj=True,
+                    auto_optimize=auto_optimize,
+                    verbose=verbose,
+                    plot=False, # hardcoded. unavaiable in enmapbox.
+                    smooth_output=smooth,
+                    contamination=contamination,
+                    percentile=percentile,
+                    num_samples=samples,
+                    buffer_size=buffer,
+                    n_jobs=n_jobs,
+                )
+        except (FileNotFoundError, ValueError) as e:  # user-actionable errors have clean
+            # messages in eniccs.
+            raise QgsProcessingException(str(e))
+        except Exception as e: # all others
+            import traceback
+            for line in traceback.format_exc().splitlines():
+                feedback.reportError(line)
+            raise QgsProcessingException(f'EnICCS failed: {e}')
+
+        # securely find filepath even if other *EnICCS.. files are present in output_dir
+        cloud_path = os.path.join(output_dir, f'{mask_obj.datatake_name}_EnICCS_CLOUD.tif')
+        shadow_path = os.path.join(output_dir, f'{mask_obj.datatake_name}_EnICCS_CLOUDSHADOW.tif')
+        if not os.path.exists(cloud_path) or not os.path.exists(shadow_path):
+            raise QgsProcessingException(
+                f'EnICCS finished but expected output rasters were not found in {output_dir}.'
+            )
+
+        return {
+            self.P_OUTPUT_CLOUD: cloud_path,
+            self.P_OUTPUT_SHADOW: shadow_path,
+        }

--- a/enmapbox/apps/eniccsapp/eniccscloudmaskalgorithm.py
+++ b/enmapbox/apps/eniccsapp/eniccscloudmaskalgorithm.py
@@ -107,7 +107,7 @@ class EniccsCloudMaskAlgorithm(EnMAPProcessingAlgorithm):
         if run_eniccs is None:
             raise QgsProcessingException(
                 'The eniccs package is not installed. '
-                'Install it with: pip install eniccs'
+                'Install it with: pip install eniccs or conda install -c conda-forge eniccs'
             )
 
         folder = self.parameterAsFile(parameters, self.P_PRODUCT, context) # fallback for out_dir


### PR DESCRIPTION
### Implements #1324: adds `run_eniccs` ([ENICCS](https://github.com/leleist/eniccs)) as an enmap-box processing algorithm.

- Filled the scaffold provided to bind eniccs' main wrapper function `run_eniccs` to the processing algorithm. 
- Added an import guard for the case where eniccs is not preinstalled (e.g., Windows installation pathway). Here, a clean install hint is provided. Within enmapbox, eniccs remains visible also without installation. 
- Added `verbose` and `n_jobs` parameters and a custom `output_directory` option with fallback.
- Additionally added routing for eniccs prints if `verbose=True`, and specific eniccs error messages because they clearly explain common config pitfalls.

### Installation
The installation strategy/procedure of enmap-box remained somewhat complex to me, and I'd much appreciate your input on that.
- eniccs 0.2.4 is now available on PyPI and conda-forge. However, I have not yet configured enmapbox to consider the conda-forge path.
- eniccs comes with relatively heavy dependencies (rasterio) and I was unsure how you prefer to handle that. 

### Compatibility: 
- QGIS 3.40 still came with numpy 1.x, which collided with rasterio. Thus, a `pip install eniccs` would install numpy version 2.x, shadowing the default numpy version and causing enmap-box to crash. Here, the conda-forge pathway would be the only feasible way (imo) 
- QGIS 3.44.12 comes with numpy 2.4.6, which already satisfies rasterio 1.5, so pip doesn't pull a second numpy. No problems here. 

### Testing: 
- Tested the processingalgorithm and pip install on a clean QGIS 3.44.12 install. 